### PR TITLE
forward dbConnection dependency to datehandler.ApplicationStatus()

### DIFF
--- a/mc-desktop/mc-desktop.py
+++ b/mc-desktop/mc-desktop.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
         # initialize a dbConnection and an object that holds the applications' status information
         # those objects are supposed to be passed around the whole app, so every component has access to these infos and can change them
         dbConnection = dbconnection.DatabaseConnection(envvariables.DB_PATH)
-        appStatus = datehandler.ApplicationStatus()
+        appStatus = datehandler.ApplicationStatus(dbConnection)
 
         # do some other stuff that needs both dbConnection and appStatus
         mainWindow = MainWindow(appStatus, dbConnection)


### PR DESCRIPTION
If you define a dependency to an object in the constructor you also have to forward the respective dependency, when you create the object.